### PR TITLE
Fix nested json object rendering

### DIFF
--- a/HTTPieCodeGenerator.coffee
+++ b/HTTPieCodeGenerator.coffee
@@ -113,6 +113,44 @@ HTTPieCodeGenerator = ->
                     sign = "#{if typeof(value) == 'string' then "=" else ":="}"
                     s += "    #{addslashes key}#{sign}#{@json_body_object(value)} \\\n"
         return s
+        
+    @nested_array_object = (array, level) ->
+      s = '['
+      for index of array
+        value = array[index]
+        indentationString = '  '.repeat(level - 1)
+        if typeof value == 'object'
+          if value.length != null
+            s += @nested_array_object(value, level)
+          else
+            s += '{\n' + @nested_hash_object(value, level) + indentationString + '}'
+        else
+          s += @json_body_object(value)
+        if index < array.length - 1
+          s += ', '
+      s += ']'
+      s
+
+    @nested_hash_object = (object, level) ->
+      s = ''
+      keys = Object.keys(object)
+      for index of keys
+        key = keys[index]
+        value = object[key]
+        indentationString = '  '.repeat(level)
+        s += indentationString
+        s += '"' + addslashes(key) + '": '
+        if typeof value == 'object'
+          if value.length != null
+            s += @nested_array_object(value, level + 1)
+          else
+            s += '{\n' + @nested_hash_object(value, level + 1) + indentationString + '}'
+        else
+          s += @json_body_object(value)
+        if index < keys.length - 1
+          s += ', '
+        s += ' \n'
+      s
 
     @strip_last_backslash = (string) ->
         # Remove the last backslash on the last non-empty line

--- a/HTTPieCodeGenerator.coffee
+++ b/HTTPieCodeGenerator.coffee
@@ -111,7 +111,12 @@ HTTPieCodeGenerator = ->
                 s = ""
                 for key, value of object
                     sign = "#{if typeof(value) == 'string' then "=" else ":="}"
-                    s += "    #{addslashes key}#{sign}#{@json_body_object(value)} \\\n"
+                    if typeof value == 'object'
+                      s += addslashes(key) + sign
+                      if value.length != null
+                        s += @nested_array_object(value, 1)
+                    else
+                      s += '\'{\n' + @nested_hash_object(value, 1) + '}\''
         return s
         
     @nested_array_object = (array, level) ->


### PR DESCRIPTION
`:=` renders raw JSON, not nested values using normal httpie syntax

Right now, it doesn't work because nested objects are rendered as:
`key:= inner=3`
which is invalid in HTTPie (I use latest, 0.9.3)
The correct syntax is:
`key:= '{"inner": 3}'`
That's basically what the changes do

I edited the JS version that was used in Paw not knowing it was originally written in Coffeescript. I haven't had time to test the coffee script version yet (just used js2coffee) but the JS versions works for me so if you want to see that, let me know.