### PR TITLE
Add support for Basic Authentication using `--auth`

### DIFF
--- a/HTTPieCodeGenerator.coffee
+++ b/HTTPieCodeGenerator.coffee
@@ -35,6 +35,9 @@ HTTPieCodeGenerator = ->
 
     @headers = (request) ->
         headers = request.headers
+
+        delete headers['Authorization'] if request.httpBasicAuth
+
         return {
             "has_headers": Object.keys(headers).length > 0
             "header_list": ({
@@ -140,6 +143,7 @@ HTTPieCodeGenerator = ->
             "method": request.method.toUpperCase()
             "url": @url request
             "headers": @headers request
+            "basicAuth": request.httpBasicAuth
             "body": @body request
 
         template = readFile "httpie.mustache"

--- a/httpie.mustache
+++ b/httpie.mustache
@@ -10,6 +10,10 @@ http{{#body.has_form_encoded}} --form{{/body.has_form_encoded}}{{#body.has_json_
 {{/headers.header_list}}
 {{/headers.has_headers}}
 {{! ----- }}
+{{#basicAuth}}
+    --auth {{{basicAuth.username}}}:{{{basicAuth.password}}} \
+{{/basicAuth}}
+{{! ----- }}
 {{#body.has_url_encoded_body}}
 {{#body.url_encoded_body}}
     '{{{name}}}'='{{{value}}}' \


### PR DESCRIPTION
Use [HTTPie’s `--auth`](https://httpie.org/doc#authentication) parameter instead of the `Authorization` header for Basic Authentication.

This also makes it more obvious when credentials are hidden:

```
http GET 'https://echo.paw.cloud/' \
    -a alice:***** Hidden credentials *****
```

in comparison to

```
http GET 'https://echo.paw.cloud/' \
    'Authorization':'Basic YWxpY2U6KioqKiogSGlkZGVuIGNyZWRlbnRpYWxzICoqKioq'
```